### PR TITLE
add Create VP button for creating verifiable presentation share response token

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2050,6 +2050,11 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/js-cookie": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@types/js-cookie/-/js-cookie-2.2.6.tgz",
+      "integrity": "sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw=="
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -2396,6 +2401,11 @@
         "@webassemblyjs/wast-parser": "1.8.5",
         "@xtuc/long": "4.2.2"
       }
+    },
+    "@xobotyi/scrollbar-width": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/@xobotyi/scrollbar-width/-/scrollbar-width-1.9.5.tgz",
+      "integrity": "sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ=="
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -3451,6 +3461,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
+    "bowser": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-1.9.4.tgz",
+      "integrity": "sha512-9IdMmj2KjigRq6oWhmwv1W36pDuA4STQZ8q6YO9um+x07xgYNCD3Oou+WP/3L1HNz7iqythGet3/p4wvc8AAwQ=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -4307,6 +4322,14 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "copy-to-clipboard": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
     "core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
@@ -4494,6 +4517,15 @@
             "uniq": "^1.0.1"
           }
         }
+      }
+    },
+    "css-in-js-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-2.0.1.tgz",
+      "integrity": "sha512-PJF0SpJT+WdbVVt0AOYp9C8GnuruRlL/UFW7932nLWmFLQTaWEzTBQEx7/hn4BuV+WON75iAViSUJLiU3PKbpA==",
+      "requires": {
+        "hyphenate-style-name": "^1.0.2",
+        "isobject": "^3.0.1"
       }
     },
     "css-loader": {
@@ -5339,6 +5371,14 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "error-stack-parser": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
+      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "requires": {
+        "stackframe": "^1.1.1"
       }
     },
     "es-abstract": {
@@ -6315,6 +6355,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
+    "fast-shallow-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-shallow-equal/-/fast-shallow-equal-1.0.0.tgz",
+      "integrity": "sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw=="
+    },
+    "fastest-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fastest-stable-stringify/-/fastest-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-kSLUBtTJ2YvqZEpraFPVh0uHsCg="
+    },
     "faye-websocket": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
@@ -7231,6 +7281,11 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
       "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
     },
+    "hyphenate-style-name": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
+      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -7347,6 +7402,15 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
+    "inline-style-prefixer": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-4.0.2.tgz",
+      "integrity": "sha512-N8nVhwfYga9MiV9jWlwfdj1UDIaZlBFu4cJSJkIr7tZX7sHpHhGR5su1qdpW+7KPL8ISTvCIkcaFi/JdBknvPg==",
+      "requires": {
+        "bowser": "^1.7.3",
+        "css-in-js-utils": "^2.0.0"
+      }
     },
     "inquirer": {
       "version": "7.3.3",
@@ -8334,6 +8398,11 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
+    "js-cookie": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-2.2.1.tgz",
+      "integrity": "sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ=="
+    },
     "js-sha3": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
@@ -9215,6 +9284,28 @@
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
       "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
+    "nano-css": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/nano-css/-/nano-css-5.3.0.tgz",
+      "integrity": "sha512-uM/9NGK9/E9/sTpbIZ/bQ9xOLOIHZwrrb/CRlbDHBU/GFS7Gshl24v/WJhwsVViWkpOXUmiZ66XO7fSB4Wd92Q==",
+      "requires": {
+        "css-tree": "^1.0.0-alpha.28",
+        "csstype": "^2.5.5",
+        "fastest-stable-stringify": "^1.0.1",
+        "inline-style-prefixer": "^4.0.0",
+        "rtl-css-js": "^1.9.0",
+        "sourcemap-codec": "^1.4.1",
+        "stacktrace-js": "^2.0.0",
+        "stylis": "3.5.0"
+      },
+      "dependencies": {
+        "csstype": {
+          "version": "2.6.14",
+          "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.14.tgz",
+          "integrity": "sha512-2mSc+VEpGPblzAxyeR+vZhJKgYg0Og0nnRi7pmRXFYYxSfnOnW8A5wwQb4n4cE2nIOzqKOAzLCaEX6aBmNEv8A=="
+        }
+      }
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -11693,6 +11784,32 @@
         "react-lifecycles-compat": "^3.0.4"
       }
     },
+    "react-universal-interface": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-universal-interface/-/react-universal-interface-0.6.2.tgz",
+      "integrity": "sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw=="
+    },
+    "react-use": {
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/react-use/-/react-use-15.3.4.tgz",
+      "integrity": "sha512-cHq1dELW6122oi1+xX7lwNyE/ugZs5L902BuO8eFJCfn2api1KeuPVG1M/GJouVARoUf54S2dYFMKo5nQXdTag==",
+      "requires": {
+        "@types/js-cookie": "2.2.6",
+        "@xobotyi/scrollbar-width": "1.9.5",
+        "copy-to-clipboard": "^3.2.0",
+        "fast-deep-equal": "^3.1.3",
+        "fast-shallow-equal": "^1.0.0",
+        "js-cookie": "^2.2.1",
+        "nano-css": "^5.2.1",
+        "react-universal-interface": "^0.6.2",
+        "resize-observer-polyfill": "^1.5.1",
+        "screenfull": "^5.0.0",
+        "set-harmonic-interval": "^1.0.1",
+        "throttle-debounce": "^2.1.0",
+        "ts-easing": "^0.2.0",
+        "tslib": "^2.0.0"
+      }
+    },
     "read-pkg": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -11979,6 +12096,11 @@
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
     },
+    "resize-observer-polyfill": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
+    },
     "resolve": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.0.tgz",
@@ -12155,6 +12277,14 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA=="
     },
+    "rtl-css-js": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/rtl-css-js/-/rtl-css-js-1.14.0.tgz",
+      "integrity": "sha512-Dl5xDTeN3e7scU1cWX8c9b6/Nqz3u/HgR4gePc1kWXYiQWVQbKCEyK6+Hxve9LbcJ5EieHy1J9nJCN3grTtGwg==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
+    },
     "run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -12290,6 +12420,11 @@
         "ajv": "^6.12.4",
         "ajv-keywords": "^3.5.2"
       }
+    },
+    "screenfull": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.0.2.tgz",
+      "integrity": "sha512-cCF2b+L/mnEiORLN5xSAz6H3t18i2oHh9BA8+CQlAh5DRw2+NFAGQJOSYbcGw8B2k04g/lVvFcfZ83b3ysH5UQ=="
     },
     "scrypt-js": {
       "version": "3.0.1",
@@ -12457,6 +12592,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "set-harmonic-interval": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/set-harmonic-interval/-/set-harmonic-interval-1.0.1.tgz",
+      "integrity": "sha512-AhICkFV84tBP1aWqPwLZqFvAwqEoVA9kxNMniGEUvzOlm4vLmOFLiTT3UZ6bziJTy4bOVpzWGTfSCbmaayGx8g=="
     },
     "set-value": {
       "version": "2.0.1",
@@ -12829,6 +12969,11 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
     },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -12925,10 +13070,49 @@
       "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
       "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
     },
+    "stack-generator": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.5.tgz",
+      "integrity": "sha512-/t1ebrbHkrLrDuNMdeAcsvynWgoH/i4o8EGGfX7dEYDoTXOYVAkEpFdtshlvabzc6JlJ8Kf9YdFEoz7JkzGN9Q==",
+      "requires": {
+        "stackframe": "^1.1.1"
+      }
+    },
     "stack-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.2.tgz",
       "integrity": "sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA=="
+    },
+    "stackframe": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
+      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+    },
+    "stacktrace-gps": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.0.4.tgz",
+      "integrity": "sha512-qIr8x41yZVSldqdqe6jciXEaSCKw1U8XTXpjDuy0ki/apyTn/r3w9hDAAQOhZdxvsC93H+WwwEu5cq5VemzYeg==",
+      "requires": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.1.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI="
+        }
+      }
+    },
+    "stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "requires": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -13295,6 +13479,11 @@
         }
       }
     },
+    "stylis": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
+      "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw=="
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -13492,6 +13681,11 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo="
     },
+    "throttle-debounce": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.3.0.tgz",
+      "integrity": "sha512-H7oLPV0P7+jgvrk+6mwwwBDmxTaxnu9HMXmloNLXwnNO0ZxZ31Orah2n8lU1eMPvsaowP2CX+USCgyovXfdOFQ=="
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -13626,6 +13820,11 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+    },
     "toidentifier": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
@@ -13647,6 +13846,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "ts-easing": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ts-easing/-/ts-easing-0.2.0.tgz",
+      "integrity": "sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ=="
     },
     "ts-pnp": {
       "version": "1.1.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react-loader-spinner": "3.1.14",
     "react-router-bootstrap": "0.25.0",
     "react-router-dom": "5.2.0",
-    "react-scripts": "3.4.3"
+    "react-scripts": "3.4.3",
+    "react-use": "^15.3.4"
   },
   "scripts": {
     "start": "REACT_APP_ENVIRONMENT=prod react-scripts start",

--- a/src/containers/CreateVerifiablePresentationModal.js
+++ b/src/containers/CreateVerifiablePresentationModal.js
@@ -1,0 +1,60 @@
+import React, {useEffect, useState} from "react";
+import {Button, ControlLabel, FormControl, FormGroup, Modal} from "react-bootstrap";
+import {useAsyncFn} from "react-use";
+
+async function createCredentialShareResponseToken(credential, requesterDid) {
+    const credentialRequirements = [{ type: credential.type }]
+    const credentialShareRequestToken = await window.sdk.createCredentialShareRequestTokenFromRequesterDid(credentialRequirements, requesterDid)
+
+    return window.sdk.createCredentialShareResponseToken(credentialShareRequestToken, [credential]);
+}
+
+export const CreateVerifiablePresentationModal = ({ credential, onClose }) => {
+    const [requesterDid, setRequesterDid] = useState('')
+
+    const [{ loading, value: credentialShareResponseToken, error }, onCreateVP] = useAsyncFn(
+        async () => createCredentialShareResponseToken(credential, requesterDid),
+        [credential, requesterDid]
+    );
+
+    useEffect(() => {
+        if (!loading && error !== undefined) {
+            alert(error.message)
+        }
+    }, [loading, error])
+
+    return (
+        <Modal
+            show={credential !== undefined}
+            onHide={onClose}
+        >
+            <Modal.Header closeButton>
+                <Modal.Title>Create Verifiable Presentation</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <FormGroup controlId='requesterDid' bsSize='large'>
+                    <ControlLabel>Requester Did</ControlLabel>
+                    <FormControl
+                        autoFocus
+                        type='text'
+                        value={requesterDid}
+                        onChange={ event => setRequesterDid(event.target.value) }
+                    />
+                </FormGroup>
+                <FormGroup>
+                    <Button bsSize='large' onClick={onCreateVP} disabled={loading}>
+                        Create
+                    </Button>
+                </FormGroup>
+                <FormGroup controlId='shareResponseToken' bsSize='large'>
+                    <ControlLabel>Share Response Token</ControlLabel>
+                    <FormControl
+                        readOnly
+                        type='text'
+                        value={loading ? '-' : credentialShareResponseToken || ''}
+                    />
+                </FormGroup>
+            </Modal.Body>
+        </Modal>
+    )
+}

--- a/src/containers/Home.css
+++ b/src/containers/Home.css
@@ -56,6 +56,15 @@
   margin: 20px 0;
 }
 
+.ValidateArea > div:first-child {
+  display: flex;
+  flex-direction: row;
+}
+
+.ValidateArea > div:first-child > button {
+  margin-right: 15px
+}
+
 .ValidateError {
   display: flex;
   align-items: center;

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -58,7 +58,7 @@ class Home extends Component {
     for (const verifiableCredential of verifiableCredentials) {
       const { credential } = verifiableCredential
 
-      const value = JSON.stringify({ ...credential, '@context': undefined }, undefined, '\t')
+      const value = JSON.stringify(credential, undefined, '\t')
 
       credentialsList.push(
         <div>

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -1,7 +1,8 @@
-import React, { Component, Fragment } from 'react'
-import { Button } from 'react-bootstrap'
-import './Home.css'
+import React, {Component, Fragment} from 'react'
 import { getVCNamePersonV1Context, getVCEmailPersonV1Context, getVCPhonePersonV1Context } from '@affinidi/vc-data'
+import {Button} from 'react-bootstrap'
+import './Home.css'
+import { CreateVerifiablePresentationModal } from "./CreateVerifiablePresentationModal";
 
 const loadingGif = require('../static/images/loading.gif')
 
@@ -39,7 +40,8 @@ class Home extends Component {
       isLoading: false,
       credentials: [],
       did: null,
-      verifiableCredentials: []
+      verifiableCredentials: [],
+      verifiablePresentationModalCredential: undefined
     }
   }
 
@@ -55,16 +57,20 @@ class Home extends Component {
 
     for (const verifiableCredential of verifiableCredentials) {
       const { credential } = verifiableCredential
-      delete credential['@context']
 
-      const value = JSON.stringify(credential, undefined, '\t')
+      const value = JSON.stringify({ ...credential, '@context': undefined }, undefined, '\t')
 
       credentialsList.push(
         <div>
           <div className='ValidateArea'>
-            <Button type='button' bsSize='lg' disabled={this.state.isLoading} onClick={ event => this.validateCredential(event, credential.id) }>
-              Validate
-            </Button>
+            <div>
+              <Button type='button' bsSize='lg' disabled={this.state.isLoading} onClick={ event => this.validateCredential(event, credential.id) }>
+                Validate
+              </Button>
+              <Button type='button' bsSize='lg' disabled={this.state.isLoading} onClick={ event => this.openVerifiablePresentationModal(event, credential) }>
+                Create VP
+              </Button>
+            </div>
             { this.state.isLoading &&
               <img className='LoadingGif' src={loadingGif} alt="loading gif"/>
             }
@@ -142,6 +148,16 @@ class Home extends Component {
       console.log(error)
       alert(error.message)
     }
+  }
+
+  openVerifiablePresentationModal(event, credential) {
+    event.preventDefault()
+
+    this.setState({ verifiablePresentationModalCredential: credential })
+  }
+
+  closeVerifiablePresentationModal() {
+    this.setState({ verifiablePresentationModalCredential: undefined })
   }
 
   // Depending on whether the username is a phone number, email, or neither,
@@ -239,7 +255,7 @@ class Home extends Component {
   }
 
   render() {
-    const { did, verifiableCredentials } = this.state
+    const { did, verifiableCredentials, verifiablePresentationModalCredential } = this.state
 
     const haveCredentials = verifiableCredentials && verifiableCredentials.length > 0
     const { isAuthenticated } = this.props
@@ -274,6 +290,11 @@ class Home extends Component {
 
           </form>
         </div>
+        {verifiablePresentationModalCredential && (
+            <CreateVerifiablePresentationModal
+                credential={verifiablePresentationModalCredential}
+                onClose={() => this.closeVerifiablePresentationModal()} />
+        )}
       </Fragment>
     )
   }


### PR DESCRIPTION
## Motivation
To add a `Create VP` button to the credential listing for creating Verifiable Presentations. A modal is opened when the button is clicked. The user can enter a `requesterDid` to which the Verifiable Presentation will be addressed to.

## Notes
- We create a share response token using the `createCredentialShareResponseToken` method. Instead of creating a VP using the `createPresentationFromChallenge` method.
- Since we do not have a `credentialShareRequestToken`, we create an invalid JWT using the user input `requesterDid`