### PR TITLE
add credential sharing for input credential share request token

### DIFF
--- a/src/containers/CredentialShareModal.js
+++ b/src/containers/CredentialShareModal.js
@@ -1,0 +1,174 @@
+import React, {useEffect} from "react";
+import {Alert, Table, Button, ControlLabel, FormControl, FormGroup, Modal} from "react-bootstrap";
+import {useAsync, useAsyncFn} from "react-use";
+
+function parseInfoFromToken(token) {
+    try {
+        const payload = JSON.parse(atob(token.split('.')[1]))
+        const callbackURL = (payload.interactionToken || {}).callbackURL || undefined
+        const requesterDid = (payload.iss.split(';')[0]).split(';')[0]
+
+        return { requesterDid, callbackURL }
+    } catch(err) {
+        return {}
+    }
+}
+
+async function getCredentials(credentialShareRequestToken) {
+    try {
+        const credentials = await window.sdk.getCredentials(credentialShareRequestToken)
+
+        if (!Array.isArray(credentials) || credentials.length < 1) {
+            alert('No credential found for this request!')
+            return []
+        }
+
+        return credentials
+    } catch(err) {
+        alert(err.message)
+        return []
+    }
+}
+
+async function createCredentialShareResponseToken(credentialShareRequestToken, credentials) {
+    try {
+        return await window.sdk.createCredentialShareResponseToken(credentialShareRequestToken, credentials)
+    } catch(err) {
+        alert(err.message)
+        return undefined
+    }
+}
+
+async function sendVPToCallback(callbackURL, vp) {
+    const response = await fetch(callbackURL, {
+        method: 'POST',
+        mode: 'cors',
+        cache: 'no-cache',
+        credentials: 'omit',
+        headers: {
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ vp })
+    })
+
+    if (response.status < 200 || response.status > 299) {
+        throw new Error(`${callbackURL} responded with ${response.statusText}`)
+    }
+
+    if (response.status === 204) {
+        return undefined
+    }
+
+    return response.json()
+}
+
+export const CredentialShareModal = ({ credentialShareRequestToken, onClose }) => {
+    const { requesterDid, callbackURL } = parseInfoFromToken(credentialShareRequestToken)
+
+    const { loading: credentialsLoading, value: credentials } = useAsync(
+        () => getCredentials(credentialShareRequestToken),
+        [credentialShareRequestToken]
+    )
+    const [
+        { loading: createVPLoading, value: credentialShareResponseToken },
+        onCreateVP
+    ] = useAsyncFn(
+        () => createCredentialShareResponseToken(credentialShareRequestToken, credentials),
+        [credentialShareRequestToken, credentials]
+    );
+
+    const [{ loading: callbackLoading, value: callbackResponse, error: callbackError }, sendVP] = useAsyncFn(
+        () => sendVPToCallback(callbackURL, credentialShareResponseToken),
+        [callbackURL, credentialShareResponseToken]
+    )
+
+    useEffect(() => {
+        if (callbackURL && credentialShareResponseToken) {
+            sendVP()
+        }
+    }, [callbackURL, credentialShareResponseToken])
+
+    const shareButtonDisabled = credentialsLoading || createVPLoading || callbackLoading || credentials.length < 1 || !!credentialShareResponseToken
+
+    return (
+        <Modal
+            show={credentialShareRequestToken !== undefined}
+            onHide={onClose}
+        >
+            <Modal.Header closeButton>
+                <Modal.Title>Share Credentials</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <FormGroup controlId='credentialShareRequestToken' bsSize='large'>
+                    <ControlLabel>Credential Share Request Token</ControlLabel>
+                    <FormControl
+                        readOnly
+                        type='text'
+                        value={credentialShareRequestToken}
+                    />
+                </FormGroup>
+                <FormGroup controlId='requesterDid' bsSize='large'>
+                    <ControlLabel>Requester Did</ControlLabel>
+                    <FormControl
+                        readOnly
+                        type='text'
+                        value={requesterDid || '-'}
+                    />
+                </FormGroup>
+                <FormGroup controlId='credentials' bsSize='large'>
+                    <ControlLabel>Credentials</ControlLabel>
+                    <Table striped bordered hover size='sm'>
+                        <thead>
+                            <tr>
+                                <th>#</th>
+                                <th>id</th>
+                                <th>type</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {(credentials || []).map((credential, idx) => (
+                                <tr key={credential.id}>
+                                    <td>{idx + 1}</td>
+                                    <td>{credential.id}</td>
+                                    <td>{JSON.stringify(credential.type)}</td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </Table>
+                </FormGroup>
+                <FormGroup>
+                    <Button bsSize='large' disabled={shareButtonDisabled} onClick={onCreateVP}>
+                        Accept
+                    </Button>
+                </FormGroup>
+                <FormGroup controlId='credentialShareResponseToken' bsSize='large'>
+                    <ControlLabel>Credential Share Response Token</ControlLabel>
+                    <FormControl
+                        readOnly
+                        type='text'
+                        value={createVPLoading ? '-' : credentialShareResponseToken || ''}
+                    />
+                </FormGroup>
+                {callbackURL && (callbackLoading || callbackResponse || callbackError) &&
+                    <FormGroup>
+                        {callbackLoading &&
+                            <Alert bsStyle="warning">
+                                Sending VP to callbackURL.
+                            </Alert>
+                        }
+                        {callbackResponse &&
+                            <Alert bsStyle="success">
+                                Sent VP to callbackURL successfully.
+                            </Alert>
+                        }
+                        {callbackError &&
+                            <Alert bsStyle="danger">
+                                There was an error sending VP to callbackURL. Error: {callbackError.message}
+                            </Alert>
+                        }
+                    </FormGroup>
+                }
+            </Modal.Body>
+        </Modal>
+    )
+}

--- a/src/containers/CredentialShareModal.js
+++ b/src/containers/CredentialShareModal.js
@@ -4,9 +4,9 @@ import {useAsync, useAsyncFn} from "react-use";
 
 function parseInfoFromToken(token) {
     try {
-        const payload = JSON.parse(atob(token.split('.')[1]))
+        const { payload } = window.sdk.parseToken(token)
         const callbackURL = (payload.interactionToken || {}).callbackURL || undefined
-        const requesterDid = (payload.iss.split(';')[0]).split(';')[0]
+        const requesterDid = payload.iss
 
         return { requesterDid, callbackURL }
     } catch(err) {

--- a/src/containers/Home.css
+++ b/src/containers/Home.css
@@ -26,13 +26,26 @@
 }
 
 .Home form input {
-  background-color: #f8f8f8;
   border: 1px solid #e7e7e7;
   border-radius: 4px;
   color: #777;
   padding: 15px 15px;
   margin-top: 10px;
   width: 100%;
+}
+
+input:read-only {
+  background-color: #f8f8f8;
+}
+
+.Home .ShareToken {
+  display: flex;
+  flex-direction: row;
+}
+
+.Home .ShareToken button {
+  margin-top: 10px;
+  margin-left: 10px;
 }
 
 .Home form textarea {

--- a/src/containers/Home.js
+++ b/src/containers/Home.js
@@ -3,6 +3,7 @@ import { getVCNamePersonV1Context, getVCEmailPersonV1Context, getVCPhonePersonV1
 import {Button} from 'react-bootstrap'
 import './Home.css'
 import { CreateVerifiablePresentationModal } from "./CreateVerifiablePresentationModal";
+import { CredentialShareModal } from "./CredentialShareModal";
 
 const loadingGif = require('../static/images/loading.gif')
 
@@ -41,7 +42,9 @@ class Home extends Component {
       credentials: [],
       did: null,
       verifiableCredentials: [],
-      verifiablePresentationModalCredential: undefined
+      verifiablePresentationModalCredential: undefined,
+      credentialShareRequestToken: '',
+      credentialShareRequestModalToken: undefined
     }
   }
 
@@ -160,6 +163,22 @@ class Home extends Component {
     this.setState({ verifiablePresentationModalCredential: undefined })
   }
 
+  openCredentialShareModal(event) {
+    event.preventDefault()
+
+    const { credentialShareRequestToken } = this.state
+
+    if (credentialShareRequestToken.trim().length < 1) {
+      return alert('Please enter a credential share request token.')
+    }
+
+    this.setState({ credentialShareRequestModalToken: credentialShareRequestToken })
+  }
+
+  closeCredentialShareModal() {
+    this.setState({ credentialShareRequestModalToken: undefined })
+  }
+
   // Depending on whether the username is a phone number, email, or neither,
   // returns the appropriate combination of claim and credentialMetadata
   makeClaimAndCredentialMetadata(username) {
@@ -255,7 +274,7 @@ class Home extends Component {
   }
 
   render() {
-    const { did, verifiableCredentials, verifiablePresentationModalCredential } = this.state
+    const { did, verifiableCredentials, verifiablePresentationModalCredential, credentialShareRequestModalToken } = this.state
 
     const haveCredentials = verifiableCredentials && verifiableCredentials.length > 0
     const { isAuthenticated } = this.props
@@ -279,6 +298,21 @@ class Home extends Component {
               </label>
             }
 
+            { isAuthenticated && did &&
+              <label>
+                Credential Share Request Token:
+                <div className='ShareToken'>
+                  <input
+                      type='text'
+                      autoComplete="off"
+                      name='credentialShareRequestToken'
+                      value={this.state.credentialShareRequestToken}
+                      onChange={(e) => this.setState({ credentialShareRequestToken: e.target.value })}/>
+                  <Button bsSize='large' onClick={(event) => this.openCredentialShareModal(event)}>Share</Button>
+                </div>
+              </label>
+            }
+
             <br />
 
             { isAuthenticated && haveCredentials &&
@@ -294,6 +328,11 @@ class Home extends Component {
             <CreateVerifiablePresentationModal
                 credential={verifiablePresentationModalCredential}
                 onClose={() => this.closeVerifiablePresentationModal()} />
+        )}
+        {credentialShareRequestModalToken && (
+            <CredentialShareModal
+                credentialShareRequestToken={credentialShareRequestModalToken}
+                onClose={() => this.closeCredentialShareModal()} />
         )}
       </Fragment>
     )

--- a/src/utils/sdkService.js
+++ b/src/utils/sdkService.js
@@ -135,6 +135,11 @@ class SdkService {
     return this.jwtService.encodeObjectToJWT(jwtObject)
   }
 
+  async getCredentials(credentialShareRequestToken, fetchBackupCredentials) {
+    const networkMember = await this.init()
+    return networkMember.getCredentials(credentialShareRequestToken, fetchBackupCredentials)
+  }
+
   async createCredentialShareResponseToken(credentialShareRequestToken, suppliedCredentials) {
     const networkMember = await this.init()
     return networkMember.createCredentialShareResponseToken(credentialShareRequestToken, suppliedCredentials)

--- a/src/utils/sdkService.js
+++ b/src/utils/sdkService.js
@@ -144,6 +144,10 @@ class SdkService {
     const networkMember = await this.init()
     return networkMember.createCredentialShareResponseToken(credentialShareRequestToken, suppliedCredentials)
   }
+
+  parseToken(token) {
+    return JwtService.fromJWT(token)
+  }
 }
 
 export default SdkService


### PR DESCRIPTION
## Motivation
Users can share their credentials with verifiers by inputting credential share request token

- user inputs credential share request token
- modal is opened showing the user the VCs the verifier requests
- user can accept to share the VCs
- a credential share response token is generated
- if the request token has a `interactionToken.callbackURL` a post request is made to this URL with body `{ vp: credentialShareResponseToken }`
- the credentialShareResponseToken is shown to the user

![image](https://user-images.githubusercontent.com/3743507/99731887-96b56800-2acf-11eb-9faa-358e6776f370.png)