### PR TITLE
refactor init to read from localStorage

### DIFF
--- a/src/utils/sdkService.js
+++ b/src/utils/sdkService.js
@@ -1,48 +1,74 @@
 import decodeEnv from './decodeEnv'
 import { AffinityWallet as Wallet } from '@affinidi/wallet-browser-sdk'
+import { __dangerous } from '@affinidi/wallet-core-sdk'
 import { Affinidi } from '@affinidi/common'
 import JwtService from "@affinidi/common/dist/services/JwtService";
 import { randomBytes } from "@affinidi/common/dist/shared/randomBytes";
+import SdkError from "@affinidi/wallet-core-sdk/dist/shared/SdkError";
+
+const { WalletStorageService } = __dangerous
+
+const SDK_AUTHENTICATION_LOCAL_STORAGE_KEY = 'affinidi:accessToken'
+const SDK_OPTIONS = {
+  env: decodeEnv(process.env.REACT_APP_ENVIRONMENT || process.env.NODE_ENV),
+  apiKey: process.env.REACT_APP_API_KEY
+}
+
+class SDKConfigurator {
+  static getSdkOptions() {
+    const { env, apiKey } = SDK_OPTIONS
+    const options = Wallet.setEnvironmentVarialbles({ env })
+
+    return Object.assign({}, options, { apiKey, env })
+  }
+}
 
 class SdkService {
   constructor() {
-    const apiKey = process.env.REACT_APP_API_KEY
-
-    this.options = {
-      env: decodeEnv(process.env.REACT_APP_ENVIRONMENT || process.env.NODE_ENV),
-      apiKey
-    }
     this.sdk = Wallet
     this.jwtService = new JwtService()
   }
 
   async init() {
-    const networkMember = await this.sdk.init(this.options)
-    return networkMember
+    const accessToken = localStorage.getItem(SDK_AUTHENTICATION_LOCAL_STORAGE_KEY)
+
+    if (!accessToken) {
+      throw new SdkError('COR-9')
+    }
+
+    const { env, apiKey } = SDK_OPTIONS
+    const { keyStorageUrl } = SDKConfigurator.getSdkOptions(env, apiKey)
+
+    const encryptedSeed = await WalletStorageService.pullEncryptedSeed(accessToken, keyStorageUrl, SDK_OPTIONS)
+    const encryptionKey = await WalletStorageService.pullEncryptionKey(accessToken)
+
+    return new this.sdk(encryptionKey, encryptedSeed, { ...SDK_OPTIONS, cognitoUserTokens: { accessToken }})
   }
 
   async signOut() {
     const networkMember = await this.init()
     await networkMember.signOut()
+    localStorage.removeItem(SDK_AUTHENTICATION_LOCAL_STORAGE_KEY)
   }
 
   async signUp(username, password, messageParameters) {
-    const token = await this.sdk.signUp(username, password, this.options, messageParameters)
+    const token = await this.sdk.signUp(username, password, SDK_OPTIONS, messageParameters)
     return token
   }
 
   async confirmSignUp(token, confirmationCode, options = {}) {
-    await this.sdk.confirmSignUp(
-      token,
-      confirmationCode,
-      { ...options, ...this.options}
+    const networkMember = await this.sdk.confirmSignUp(
+        token,
+        confirmationCode,
+        { ...options, ...SDK_OPTIONS}
     )
+    SdkService._saveAccessTokenToLocalStorage(networkMember)
   }
 
   async resendSignUpConfirmationCode(username, messageParameters) {
     // ISSUE: CommonNetworkMember.resendSignUpConfirmationCode does not call CommonNetworkMember.setEnvironmentVarialbles(options)
     // So the below call will always return 'User not found'
-    await this.sdk.resendSignUpConfirmationCode(username, this.options, messageParameters)
+    await this.sdk.resendSignUpConfirmationCode(username, SDK_OPTIONS, messageParameters)
   }
 
   async getDidAndCredentials() {
@@ -62,55 +88,58 @@ class SdkService {
 
   async validateCredential(credential) {
     //TODO: pass correct registryURL to constructor
-    const affinidi = new Affinidi({ apiKey: this.options.apiKey })
+    const affinidi = new Affinidi({ apiKey: SDK_OPTIONS.apiKey })
     const result = await affinidi.validateCredential(credential)
 
     return result
   }
 
   async fromLoginAndPassword(username, password) {
-    const networkMember = await this.sdk.fromLoginAndPassword(username, password, this.options)
+    const networkMember = await this.sdk.fromLoginAndPassword(username, password, SDK_OPTIONS)
+    SdkService._saveAccessTokenToLocalStorage(networkMember)
     return networkMember
   }
 
   async changeUsername(username) {
     const networkMember = await this.init()
-    await networkMember.changeUsername(username, this.options)
+    await networkMember.changeUsername(username, SDK_OPTIONS)
   }
 
   async confirmChangeUsername(username, confirmationCode) {
     const networkMember = await this.init()
-    await networkMember.confirmChangeUsername(username, confirmationCode, this.options)
+    await networkMember.confirmChangeUsername(username, confirmationCode, SDK_OPTIONS)
   }
 
   async passwordlessLogin(username, messageParameters) {
-    const token = await this.sdk.passwordlessLogin(username, this.options, messageParameters)
+    const token = await this.sdk.passwordlessLogin(username, SDK_OPTIONS, messageParameters)
     return token
   }
 
   async completeLoginChallenge(token, confirmationCode) {
-    await this.sdk.completeLoginChallenge(token, confirmationCode, this.options)
+    const networkMember = await this.sdk.completeLoginChallenge(token, confirmationCode, SDK_OPTIONS)
+    SdkService._saveAccessTokenToLocalStorage(networkMember)
+    return networkMember
   }
 
   async forgotPassword(username, messageParameters) {
-    await this.sdk.forgotPassword(username, this.options, messageParameters)
+    await this.sdk.forgotPassword(username, SDK_OPTIONS, messageParameters)
   }
 
   async forgotPasswordSubmit(username, confirmationCode, password) {
-    await this.sdk.forgotPasswordSubmit(username, confirmationCode, password, this.options)
+    await this.sdk.forgotPasswordSubmit(username, confirmationCode, password, SDK_OPTIONS)
   }
 
   async register(password) {
-    return this.sdk.register(password, this.options)
+    return this.sdk.register(password, SDK_OPTIONS)
   }
 
   async signUpWithExistsEntity(keyParams, username, password, messageParameters) {
-    return this.sdk.signUpWithExistsEntity(keyParams, username, password, this.options, messageParameters)
+    return this.sdk.signUpWithExistsEntity(keyParams, username, password, SDK_OPTIONS, messageParameters)
   }
 
   async changePassword(oldPassword, newPassword) {
     const networkMember = await this.init()
-    return networkMember.changePassword(oldPassword, newPassword, this.options)
+    return networkMember.changePassword(oldPassword, newPassword, SDK_OPTIONS)
   }
 
   async createCredentialShareRequestTokenFromRequesterDid(credentialRequirements, requesterDid) {
@@ -157,6 +186,14 @@ class SdkService {
 
   parseToken(token) {
     return JwtService.fromJWT(token)
+  }
+
+  static _saveAccessTokenToLocalStorage(networkMember) {
+    try {
+      localStorage.setItem(SDK_AUTHENTICATION_LOCAL_STORAGE_KEY, networkMember.accessToken)
+    } catch (err) {
+      console.error(err)
+    }
   }
 }
 


### PR DESCRIPTION
## Motivation
SDK by default saves/loads access token from the sessionStorage. This causes the user to logout once he closes the tab.
This also means that if the user navigates to the demo react app using a link, he will not be authenticated.

This PR saves the cognito access token of the user in the localStorage so once the user logs in, he will be logged in all tabs whilst the access token is valid.
